### PR TITLE
telephony: Conditionally ignore RSSNR signal level

### DIFF
--- a/core/res/res/values/custom_config.xml
+++ b/core/res/res/values/custom_config.xml
@@ -127,4 +127,7 @@
     <!-- Whether to cleanup fingerprints upon connection to the daemon and when user switches -->
     <bool name="config_cleanupUnusedFingerprints">true</bool>
 
+    <!-- Whether device ignores the RSSNR signal implementation -->
+    <bool name="config_ignoreRssnrSignalLevel">false</bool>
+
 </resources>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -112,4 +112,7 @@
     <!-- Icon packs -->
     <java-symbol type="drawable" name="adaptive_icon_drawable_wrapper" />
 
+    <!-- Whether device ignores the RSSNR signal implementation -->
+    <java-symbol type="bool" name="config_ignoreRssnrSignalLevel" />
+
 </resources>

--- a/telephony/java/android/telephony/SignalStrength.java
+++ b/telephony/java/android/telephony/SignalStrength.java
@@ -897,6 +897,13 @@ public class SignalStrength implements Parcelable {
                 + rsrpIconLevel + " snrIconLevel:" + snrIconLevel
                 + " lteRsrpBoost:" + mLteRsrpBoost);
 
+        boolean rssnrIgnored = Resources.getSystem().getBoolean(
+                com.android.internal.R.bool.config_ignoreRssnrSignalLevel);
+        if (rssnrIgnored) {
+            // Ignore RSSNR
+            if (rsrpIconLevel != -1) return rsrpIconLevel;
+        }
+
         /* Choose a measurement type to use for notification */
         if (snrIconLevel != -1 && rsrpIconLevel != -1) {
             /*


### PR DESCRIPTION
Doesn't work properly on some devices, so allow those devices to disable this.
Based on the phhusson treble patch.

Change-Id: I513d8a1abf3faa8ac81e9c8f0ef7f12a2ebe218d
Signed-off-by: Adesh15 <adesikha15@gmail.com>